### PR TITLE
Fix checkForHeightChangesOfAddinContent for Firefox

### DIFF
--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -315,9 +315,15 @@ export class AddinClient {
    * a new post if so.
    */
   private checkForHeightChangesOfAddinContent() {
-    const style = getComputedStyle(document.body);
-    const newHeight = document.body.offsetHeight + parseInt(style.marginTop, 10) + parseInt(style.marginBottom, 10);
+    let newHeight = document.body.offsetHeight;
 
+    if (window.getComputedStyle) {
+      const style = window.getComputedStyle(document.body);
+      if (style) {
+        newHeight += parseInt(style.marginTop, 10) + parseInt(style.marginBottom, 10);
+      }
+    }
+    
     if (newHeight !== this.lastPostedIframeHeight) {
       this.lastPostedIframeHeight = newHeight;
 

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -323,7 +323,7 @@ export class AddinClient {
         newHeight += parseInt(style.marginTop, 10) + parseInt(style.marginBottom, 10);
       }
     }
-    
+
     if (newHeight !== this.lastPostedIframeHeight) {
       this.lastPostedIframeHeight = newHeight;
 


### PR DESCRIPTION
getComputedStyle fails in firefox when the element is display none.  This results in the addin not loading.  This fix makes it gracefully handle that scenario but leverage the computed style when possible.