### PR TITLE
Mtims/close flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.11 (2019-05-03)
+
+- Added a `closeFlyout` method to allow developers to close a flyout panel.
+- The `showFlyout` method will now return a Promise which will resolve when the flyout is closed.
+
 # 1.0.10 (2019-04-16)
 
 - Added a `showFlyout` method to allow developers to display supplementary information in a flyout panel.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,30 @@ The host page will launch an iframe for the URL provided, and load it as an add-
 
 As with a typical add-in, the flyout add-in should register for the `init` callback and will receive `envId` in the arguments. The `context` field for arguments will match the context object passed into the `showFlyout` call from the parent add-in.  Note that this is crossing iframes so the object has been serialized and deserialized.  It can be used for passing data but not functions.
 
+##### Closing the flyout
+An add-in is able to close the flyout by calling the `closeFlyout` function on the client:
+
+```js
+// Close an open flyout from the client
+var client = new AddinClient({...});
+client.closeFlyout();
+```
+
+The parent add-in can listen to the close event via the `flyoutClosed` Promise returned from `showFlyout`. The Promise will resolve when the flyout is closed:
+
+```js
+// Parent add-in launching a flyout
+var client = new AddinClient({...});
+var flyout = client.showFlyout({
+  url: '<flyout-addin-url>',
+  context: { /* arbitrary context object to pass to flyout */ }
+});
+
+flyout.flyoutClosed.then(() => {
+  // Handle that the flyout is closed.
+});
+```
+
 ## Authentication
 SKY add-ins support a single-sign-on (SSO) mechanism that can be used to correlate the Blackbaud user with a user in the add-in's native system.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -715,12 +715,13 @@ describe('AddinClient ', () => {
   describe('show-flyout', () => {
 
     it('should raise "show-flyout" event with proper message.',
-      () => {
+      (done) => {
         let postedMessage: any;
         let postedOrigin: string;
         let initCalled: boolean = false;
         let flyoutNextClickCalled: boolean = false;
         let flyoutPreviousClickCalled: boolean = false;
+        let flyoutClosedCalled: boolean = false;
 
         const client = new AddinClient({
           callbacks: {
@@ -754,7 +755,10 @@ describe('AddinClient ', () => {
           url: 'some url'
         };
 
-        client.showFlyout(args);
+        client.showFlyout(args)
+          .flyoutClosed.then(() => {
+            flyoutClosedCalled = true;
+          });
 
         const nextClickMsg: AddinHostMessageEventData = {
           message: {},
@@ -771,6 +775,14 @@ describe('AddinClient ', () => {
         };
 
         postMessageFromHost(previousClickMsg);
+
+        const closedMsg: AddinHostMessageEventData = {
+          message: {},
+          messageType: 'flyout-closed',
+          source: 'bb-addin-host'
+        };
+
+        postMessageFromHost(closedMsg);
 
         client.destroy();
 
@@ -789,6 +801,12 @@ describe('AddinClient ', () => {
 
         expect(flyoutNextClickCalled).toBe(true);
         expect(flyoutPreviousClickCalled).toBe(true);
+
+        // Delay the vaildation until after the post message is done.
+        setTimeout(() => {
+          expect(flyoutClosedCalled).toBe(true);
+          done();
+        }, 100);
       });
 
   });

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -793,6 +793,37 @@ describe('AddinClient ', () => {
 
   });
 
+  describe('close-flyout', () => {
+
+    it('should raise "close-flyout" event.',
+      () => {
+        let postedMessage: any;
+        let postedOrigin: string;
+
+        const client = new AddinClient({
+          callbacks: {
+            init: () => { return; }
+          }
+        });
+
+        initializeHost();
+
+        spyOn(window.parent, 'postMessage').and.callFake((message: any, targetOrigin: string) => {
+          postedMessage = message;
+          postedOrigin = targetOrigin;
+        });
+
+        client.closeFlyout();
+
+        client.destroy();
+
+        expect(postedMessage.message).toBe(undefined);
+        expect(postedMessage.messageType).toBe('close-flyout');
+        expect(postedOrigin).toBe(TEST_HOST_ORIGIN);
+      });
+
+  });
+
   describe('postMessageToHostPage', () => {
 
     it('should warn if origin is invalid.',

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -223,6 +223,15 @@ export class AddinClient {
   }
 
   /**
+   * Requests the host page to close the flyout add-in.
+   */
+  public closeFlyout() {
+    this.postMessageToHostPage({
+      messageType: 'close-flyout'
+    });
+  }
+
+  /**
    * Post a message to the host page informing it that the add-in is
    * now started and listening for messages from the host.
    */
@@ -323,6 +332,11 @@ export class AddinClient {
           case 'button-click':
             if (this.args.callbacks.buttonClick) {
               this.args.callbacks.buttonClick();
+            }
+            break;
+          case 'flyout-closed':
+            if (this.args.callbacks.flyoutClosed) {
+              this.args.callbacks.flyoutClosed();
             }
             break;
           case 'flyout-next-click':

--- a/src/addin/client-interfaces/addin-client-callbacks.ts
+++ b/src/addin/client-interfaces/addin-client-callbacks.ts
@@ -16,17 +16,12 @@ export interface AddinClientCallbacks {
   buttonClick?: () => void;
 
   /**
-   * Callback raised for flyout parent add-ins indicating that the flyout was closed.
-   */
-  flyoutClosed?: () => void;
-
-  /**
-   * Callback raised for flyout add-ins indicating that the next button was clicked.
+   * Callback raised for tile add-ins indicating that the flyout's next button was clicked.
    */
   flyoutNextClick?: () => void;
 
   /**
-   * Callback raised for flyout add-ins indicating that the previous button was clicked.
+   * Callback raised for tile add-ins indicating that the flyout's previous button was clicked.
    */
   flyoutPreviousClick?: () => void;
 

--- a/src/addin/client-interfaces/addin-client-callbacks.ts
+++ b/src/addin/client-interfaces/addin-client-callbacks.ts
@@ -16,6 +16,11 @@ export interface AddinClientCallbacks {
   buttonClick?: () => void;
 
   /**
+   * Callback raised for flyout parent add-ins indicating that the flyout was closed.
+   */
+  flyoutClosed?: () => void;
+
+  /**
    * Callback raised for flyout add-ins indicating that the next button was clicked.
    */
   flyoutNextClick?: () => void;

--- a/src/addin/client-interfaces/addin-client-show-flyout-result.ts
+++ b/src/addin/client-interfaces/addin-client-show-flyout-result.ts
@@ -1,0 +1,10 @@
+/**
+ * Interface for the return value from showing a flyout add-in.
+ */
+export interface AddinClientShowFlyoutResult {
+
+  /**
+   * A promise that will be resolved when the flyout add-in is closed.
+   */
+  flyoutClosed: Promise<void>;
+}

--- a/src/addin/client-interfaces/index.ts
+++ b/src/addin/client-interfaces/index.ts
@@ -10,6 +10,7 @@ export * from './addin-client-open-help-args';
 export * from './addin-client-ready-args';
 export * from './addin-client-ready-button-config';
 export * from './addin-client-show-flyout-args';
+export * from './addin-client-show-flyout-result';
 export * from './addin-client-show-modal-args';
 export * from './addin-client-show-modal-result';
 export * from './addin-client-show-toast-args';


### PR DESCRIPTION
Added a `closeFlyout` method to allow developers to close a flyout panel.

The `showFlyout` method will now return a Promise which will resolve when the flyout is closed.