### PR TITLE
"close" action when dialog closes due to Esc key or x icon

### DIFF
--- a/src/addin/client-interfaces/addin-confirm-button.ts
+++ b/src/addin/client-interfaces/addin-confirm-button.ts
@@ -8,6 +8,9 @@ export interface AddinConfirmButton {
   /**
    * Specifies an identifier to return when users select the button to close
    * the confirm dialog. This is useful to determine which button users select.
+   *
+   * Note: An action identifier of "close" is returned when the confirm dialog
+   * is closed using the Esc key or using the dialog's "x" icon.
    */
   action: string;
 


### PR DESCRIPTION
Adding a note to the API reference for the confirm button's "action" property to indicate that "close" will be returned as the action identifier when a confirm dialog is closed by the Esc key or the dialog's "x" icon.