### PR TITLE
Updated .travis.yml for new xvfb technique

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language: node_js
 addons:
   firefox: "52.0.2"
 
+services:
+  - xvfb
+
 branches:
   only:
     - master
     - /^[0-9]+\.[0-9]+\.[0-9]+.*/
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 
 script: npm run ci
 


### PR DESCRIPTION
We've had to make this exact change in all our repos.  TravisCI in conjunction with the default image used, changed how you use `xvfb`.

This will allow https://github.com/blackbaud/sky-addin-client/pull/25 to pass.