### PR TITLE
Tile padding/inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.0.13 (2019-10-04)
 
-- Add `removeInset` property to `AddinTileConfig` to specify whether the tile content inset should be removed
+- Added `removeInset` property to `AddinTileConfig` to specify whether the tile content inset should be removed
 which allows the content to extend all the way to the edge of the tile container (Default: false)
 
 # 1.0.12 (2019-05-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.13 (2019-09-30)
+
+- Add `paddingEnabled` property to `AddinTileConfig` to determine whether to enable padding around tile content (Default: true)
+
 # 1.0.12 (2019-05-14)
 
 - Added a `showConfirm` method to allow developers to show a confirm dialog with a title, description body,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.0.13 (2019-09-30)
+# 1.0.13 (2019-10-04)
 
-- Add `paddingEnabled` property to `AddinTileConfig` to determine whether to enable padding around tile content (Default: true)
+- Add `removeInset` property to `AddinTileConfig` to specify whether the tile content inset should be removed
+which allows the content to extend all the way to the edge of the tile container (Default: false)
 
 # 1.0.12 (2019-05-14)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/client-interfaces/addin-tile-config.ts
+++ b/src/addin/client-interfaces/addin-tile-config.ts
@@ -31,7 +31,8 @@ export interface AddinTileConfig {
   showSettings?: boolean;
 
   /**
-   * Indicates whether to enable padding around tile content (Default: true)
+   * Indicates whether the tile content inset should be removed which allows
+   * the content to extend all the way to the edge of the tile container (Default: false)
    */
-  paddingEnabled?: boolean;
+  removeInset?: boolean;
 }

--- a/src/addin/client-interfaces/addin-tile-config.ts
+++ b/src/addin/client-interfaces/addin-tile-config.ts
@@ -30,4 +30,8 @@ export interface AddinTileConfig {
    */
   showSettings?: boolean;
 
+  /**
+   * Indicates whether to enable padding around tile content (Default: true)
+   */
+  paddingEnabled?: boolean;
 }


### PR DESCRIPTION
Added `removeInset` property to `AddinTileConfig` to specify whether the tile content inset should be removed which allows the content to extend all the way to the edge of the tile container (Default: false)