### PR TITLE
Handle host-init message to obtain add-in id

### DIFF
--- a/src/addin/host-interfaces/addin-host-message.ts
+++ b/src/addin/host-interfaces/addin-host-message.ts
@@ -35,4 +35,13 @@ export interface AddinHostMessage {
    */
   reason?: string;
 
+  /**
+   * Identifier for the current add-in being handled by the client.
+   */
+  addinId?: string;
+
+  /**
+   * The origin URL of the host page.
+   */
+  origin?: string;
 }


### PR DESCRIPTION
In the case that the client cannot obtain values from the URL query string, wait for the host page's `host-init` message to get this values instead.  After these values are obtained, send the `ready` message back to the host.

Also added an additional flyout unit test to increase coverage.