### PR TITLE
Add modal config for full-page modal add-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.14 (2020-3-4)
+
+- Added `AddinModalConfig` with optional `fullPage` property (Default: false) to indicate if a modal add-in will be
+displayed full page.
+
 # 1.0.13 (2019-10-04)
 
 - Added `removeInset` property to `AddinTileConfig` to specify whether the tile content inset should be removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/client-interfaces/addin-client-ready-args.ts
+++ b/src/addin/client-interfaces/addin-client-ready-args.ts
@@ -1,4 +1,5 @@
 import { AddinButtonConfig } from './addin-button-config';
+import { AddinModalConfig } from './addin-modal-config';
 import { AddinTileConfig } from './addin-tile-config';
 
 /**
@@ -26,4 +27,9 @@ export interface AddinClientReadyArgs {
    * Provides additional configuration for Tile add-ins
    */
   tileConfig?: AddinTileConfig;
+
+ /**
+  * Provides additional configuration for Modal add-ins
+  */
+  modalConfig?: AddinModalConfig;
 }

--- a/src/addin/client-interfaces/addin-modal-config.ts
+++ b/src/addin/client-interfaces/addin-modal-config.ts
@@ -6,9 +6,8 @@ export interface AddinModalConfig {
   /**
    * Indicates that the modal is configured to display full screen (Default: false)
    *
-   * The appropriate adjustments should be made to the host page when
-   * a modal is configured to display full-page. For example, hide the
-   * help button when its display conflicts with a full-page modal.
+   * When true, this instructs the host application to adjust the display
+   * appropriately for a full-page modal.
    */
   fullPage?: boolean;
 }

--- a/src/addin/client-interfaces/addin-modal-config.ts
+++ b/src/addin/client-interfaces/addin-modal-config.ts
@@ -1,0 +1,14 @@
+/**
+ * Interface for defining configuration options for Modal add-ins
+ */
+export interface AddinModalConfig {
+
+  /**
+   * Indicates that the modal is configured to display full screen (Default: false)
+   *
+   * The appropriate adjustments should be made to the host page when
+   * a modal is configured to display full-page. For example, hide the
+   * help button when its display conflicts with a full-page modal.
+   */
+  fullPage?: boolean;
+}

--- a/src/addin/client-interfaces/index.ts
+++ b/src/addin/client-interfaces/index.ts
@@ -18,6 +18,7 @@ export * from './addin-client-show-modal-result';
 export * from './addin-client-show-toast-args';
 export * from './addin-confirm-button';
 export * from './addin-confirm-button-style';
+export * from './addin-modal-config';
 export * from './addin-tab-summary-style';
 export * from './addin-tile-config';
 export * from './addin-tile-summary-style';


### PR DESCRIPTION
Adding the `AddinModalConfig` type that enables a developer to specify that they intend to display a full-page modal - for now mainly just hiding the help button when any number of full-page modal add-ins are displaying.