### PR TITLE
Adding `updateContext` method to allow child addin to receive updates from parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.17 (2020-05-06)
+- Added `updateContext` method to allow child addin to receive updated context information from parent.
+
+
 # 1.0.16 (2020-04-22)
 - Added `showWait` and `hideWait` methods to allow developers to show/hide a page-blocking-wait, respectively.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.0.17 (2020-05-06)
-- Added `updateContext` method to allow child addin to receive updated context information from parent.
+- Added `updateContext` callback to notify add-in when context information has been updated.
 
 
 # 1.0.16 (2020-04-22)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6888,7 +6888,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -234,6 +234,58 @@ describe('AddinClient ', () => {
 
     });
 
+    describe('update-context', () => {
+
+      it('should call the "updateContext" callback.',
+        () => {
+          let contextUpdated = false;
+
+          const client = new AddinClient({
+            callbacks: {
+              updateContext: () => { contextUpdated = true; },
+              init: () => { return; }
+            }
+          });
+
+          initializeHost();
+
+          const msg: AddinHostMessageEventData = {
+            message: {},
+            messageType: 'update-context',
+            source: 'bb-addin-host'
+          };
+
+          postMessageFromHost(msg);
+          client.destroy();
+
+          expect(contextUpdated).toBe(true);
+        });
+
+      it('should tolerate the "updateContext" callback being undefined.',
+        () => {
+          const client = new AddinClient({
+            callbacks: {
+              init: () => { return; }
+            }
+          });
+
+          initializeHost();
+
+          const msg: AddinHostMessageEventData = {
+            message: {},
+            messageType: 'update-context',
+            source: 'bb-addin-host'
+          };
+
+          postMessageFromHost(msg);
+          client.destroy();
+
+          // No assertion.  Just don't fail.
+        });
+
+    });
+
+
     describe('help-click', () => {
 
       it('should call the "helpClick" callback.',

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -238,11 +238,11 @@ describe('AddinClient ', () => {
 
       it('should call the "updateContext" callback.',
         () => {
-          let contextUpdated = false;
+          let contextUpdated: boolean = false;
 
           const client = new AddinClient({
             callbacks: {
-              updateContext: () => { contextUpdated = true; },
+              updateContext: (contextId) => { contextUpdated = true; },
               init: () => { return; }
             }
           });
@@ -250,7 +250,7 @@ describe('AddinClient ', () => {
           initializeHost();
 
           const msg: AddinHostMessageEventData = {
-            message: {},
+            message: {context: {id:'123'}},
             messageType: 'update-context',
             source: 'bb-addin-host'
           };
@@ -258,7 +258,7 @@ describe('AddinClient ', () => {
           postMessageFromHost(msg);
           client.destroy();
 
-          expect(contextUpdated).toBe(true);
+          expect(contextUpdated).toBeTrue();
         });
 
       it('should tolerate the "updateContext" callback being undefined.',

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -406,6 +406,11 @@ export class AddinClient {
               this.args.callbacks.buttonClick();
             }
             break;
+          case 'update-context':
+            if (this.args.callbacks.updateContext) {
+              this.args.callbacks.updateContext();
+            }
+            break;
           case 'confirm-closed':
             if (this.confirmRequest) {
               this.confirmRequest.resolve(data.message.reason);

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -408,7 +408,7 @@ export class AddinClient {
             break;
           case 'update-context':
             if (this.args.callbacks.updateContext) {
-              this.args.callbacks.updateContext();
+              this.args.callbacks.updateContext(data.message);
             }
             break;
           case 'confirm-closed':

--- a/src/addin/client-interfaces/addin-client-callbacks.ts
+++ b/src/addin/client-interfaces/addin-client-callbacks.ts
@@ -18,7 +18,7 @@ export interface AddinClientCallbacks {
   /**
    * Callback raised indicating context was updated by the host.
    */
-  updateContext?: () => void;
+  updateContext?: (context: any) => void;
 
   /**
    * Callback raised for tile add-ins indicating that the flyout's next button was clicked.

--- a/src/addin/client-interfaces/addin-client-callbacks.ts
+++ b/src/addin/client-interfaces/addin-client-callbacks.ts
@@ -16,6 +16,11 @@ export interface AddinClientCallbacks {
   buttonClick?: () => void;
 
   /**
+   * Callback raised indicating context was updated by the host.
+   */
+  updateContext?: () => void;
+
+  /**
    * Callback raised for tile add-ins indicating that the flyout's next button was clicked.
    */
   flyoutNextClick?: () => void;


### PR DESCRIPTION
Child addin will be able to receive updated context information from the parent host.