### PR TITLE
feat: deprecate help-related func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.0 (2020-10-30)
+- Deprecate help widget related functionality.
+
 # 1.0.21 (2020-11-04)
 - Add support for event handler to process blocking events from the add-in host.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.0 (2020-10-30)
+# 1.1.0 (2020-11-19)
 - Deprecate help widget related functionality.
 
 # 1.0.21 (2020-11-04)

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ For tile add-ins, the URL for the add-in will be rendered in a visible iframe on
 The host page will handle rendering the tile component around the add-in iframe.  When calling the `ready` callback, the `title` field will indicate the title for the tile.  Initially, the entire tile will be hidden, and will show on the page if `showUI` is set to `true` in the callback.  You can set it to `false` to indicate that the tile should not be shown, based on the user's privileges or context of the current record, etc.
 
 Tile add-ins support an optional configuration object that can be used to further control the look/feel/behavior of the tile within the host application.  For
-example, to control whether any additional summary text/image is shown when the tile is collapsed, and control whether the "help" and "settings" icons appear
+example, to control whether any additional summary text/image is shown when the tile is collapsed, and control whether the "settings" icons appear
 in the tile header.
 
-Tile add-ins support optional callbacks for `helpClick` and `settingsClick`, which will be invoked whenever the user clicks the "help" or "settings" icons, respectively:
+Tile add-ins support optional callbacks for `settingsClick`, which will be invoked whenever the user clicks the "settings" icons, respectively:
 
 ```js
 var client = new AddinClient({
@@ -88,13 +88,9 @@ var client = new AddinClient({
         tileConfig: {
           summaryStyle: BBSkyAddinClient.AddinTileSummaryStyle.Text,
           summaryText: '18 records',
-          showHelp: true,
           showSettings: true
         }
       });
-    },
-    helpClick: () => {
-      // The user has clicked the "Help" icon in the tile header
     },
     settingsClick: () => {
       // The user has clicked the "Settings" icon in the tile header
@@ -214,15 +210,6 @@ The add-in can choose to navigate the parent page based on user interactions.  T
 ```js
 var client = new AddinClient({...});
 client.navigate({ url: '<target_url>' });
-```
-
-#### Opening the Blackbaud Help flyout
-
-The add-in can instruct the parent page to display the Help flyout, and specify which topic to display. To do this, call the `openHelp` method on the `AddinClient` object. This function takes an object argument with property `helpKey` for the name of the help topic to display. A single .html file should be named.
-
-```js
-var client = new AddinClient({...});
-client.openHelp({ helpKey: '<target_page>.html' });
 ```
 
 #### Showing a toast
@@ -389,3 +376,8 @@ catch (TokenValidationException ex)
 Once the token has been validated, the add-in's backend will know the Blackbaud user ID and can determine if a user mapping exists for a user in the add-in's system. If a mapping exists, then the add-in's backend can immediately present the content for the add-in. If no user mapping exists, the add-in can prompt the user to login.
 
 For more information on Blackbaud's SKY Add-in framework, please see https://developer.blackbaud.com/skyapi/docs/addins.
+
+## Deprecated help support
+
+Using the help widget experience in the context of an addin is generally not needed and contradicts BB's UX patterns.
+As a result, the widget support has been deprecated and will be remove in the next major release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.0.21",
+  "version": "1.1.0",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -466,6 +466,7 @@ export class AddinClient {
               this.args.callbacks.flyoutPreviousClick();
             }
             break;
+          // TODO remove support for this message type when help support is removed in next major release
           case 'help-click':
             if (this.args.callbacks.helpClick) {
               this.args.callbacks.helpClick();

--- a/src/addin/client-interfaces/addin-client-callbacks.ts
+++ b/src/addin/client-interfaces/addin-client-callbacks.ts
@@ -32,6 +32,7 @@ export interface AddinClientCallbacks {
 
   /**
    * Callback raised for tile add-ins indicating that the help button was clicked.
+   * @deprecated See _Deprecated help support_ in README
    */
   helpClick?: () => void;
 

--- a/src/addin/client-interfaces/addin-client-open-help-args.ts
+++ b/src/addin/client-interfaces/addin-client-open-help-args.ts
@@ -5,6 +5,7 @@ export interface AddinClientOpenHelpArgs {
 
   /**
    * The name of the help key to be launched.
+   * @deprecated See _Deprecated help support_ in README
    */
   helpKey: string;
 

--- a/src/addin/client-interfaces/addin-tile-config.ts
+++ b/src/addin/client-interfaces/addin-tile-config.ts
@@ -22,6 +22,7 @@ export interface AddinTileConfig {
 
   /**
    * Indicates whether to show the Help icon in the tile chrome
+   * @deprecated See _Deprecated help support_ in README
    */
   showHelp?: boolean;
 


### PR DESCRIPTION
Due to both SCD and UX preferring for the full help experience to exist in an addin context, deprecating help-related functionality for future removal. 

A dependency tweak in `skyux-lib-addin-host` allows for this to be deprecated and not removed like #46 was attempting to do.