### PR TITLE
Provide add-in config to allow for additional host origins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.0 (2024-06-18)
+- Added `AddinClientConfig` interface to allow additional host origins to be supplied by an `AddinClient`.
+
 # 1.2.2 (2024-04-25)
 - Updated `allowedOrigins` to support Good Move and fix EMC portal issues
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ var client = new AddinClient({
 });
 ```
 
+You can also allow additional origins where your add-in client may run within a Blackbaud host page. Additional origins are supplied as regular expression patterns. The `AddinClient` already allows several Blackbaud host origins by default. If you find a need to extend the defaults, you may do so by populating the `AddinClientConfig`'s `allowedOrigins` property.
+
+```js
+var client = new AddinClient({
+  callbacks: {
+    init: (args) => {
+      args.ready({
+        showUI: true,
+        title: 'My Custom Tile Title'
+      });
+    }
+  },
+  allowedOrigins: [
+    /^https\:\/\/[\w\-\.]+\.additionalblackbauddomain\.com$/,
+  ]
+});
+```
+
 #### Tile add-ins
 For tile add-ins, the URL for the add-in will be rendered in a visible iframe on the page, where you can render any custom content.  The iframe will initially be hidden until an initialize protocol is completed between the host and the add-in.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "index.ts",
   "scripts": {
     "ci": "npm run test:ci && npm run build",
-    "test": "npm run lint && npm run test:unit",
+    "test": "npm run lint && npm run test:unit:ci",
     "test:ci": "npm run test:unit:ci",
     "test:unit": "npm run test:unit:base -- config/karma/local.karma.conf.js",
     "test:unit:ci": "npm run test:unit:base -- config/karma/ci.karma.conf.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -71,6 +71,54 @@ describe('AddinClient ', () => {
 
     });
 
+    it ('should initialize AddinClient with default allowedOrigins collection', () => {
+      const client = new AddinClient({
+        callbacks: {
+          init: () => { return; }
+        }
+      });
+      client.destroy();
+
+      expect((<any>client).allowedOrigins.length).toBe(81);
+    });
+
+    it ('should initialize AddinClient with additional allowedOrigins', () => {
+      const client = new AddinClient({
+        callbacks: {
+          init: () => { return; }
+        },
+        config: {
+          allowedOrigins: [
+            /^https\:\/\/[\w\-\.]+\.additionaldomain1\.com$/,
+            /^https\:\/\/[\w\-\.]+\.additionaldomain2\.com$/,
+            /^https\:\/\/[\w\-\.]+\.additionaldomain3\.com$/
+          ]
+        }
+      });
+      client.destroy();
+
+      expect((<any>client).allowedOrigins.length).toBe(84);
+    });
+
+    it ('additional allowedOrigins - removing duplicates', () => {
+      const client = new AddinClient({
+        callbacks: {
+          init: () => { return; }
+        },
+        config: {
+          allowedOrigins: [
+            /^https\:\/\/[\w\-\.]+\.additionaldomain1\.com$/,
+            /^https\:\/\/[\w\-\.]+\.blackbaud\.com$/,
+            /^https\:\/\/[\w\-\.]+\.blackbaud\-dev\.com$/,
+            /^http\:\/\/[\w\-\.]+\.blackbaud\-dev\.com$/,
+          ]
+        }
+      });
+      client.destroy();
+
+      expect((<any>client).allowedOrigins.length).toBe(82);
+    });
+
   });
 
   describe('getAuthToken', () => {
@@ -253,7 +301,7 @@ describe('AddinClient ', () => {
           const client = new AddinClient({
             callbacks: {
               init: () => { return; },
-              updateContext: (contextId) => { contextUpdated = true; }
+              updateContext: () => { contextUpdated = true; }
             }
           });
 
@@ -1221,7 +1269,7 @@ describe('AddinClient ', () => {
 
     it('should add a callback function for the provided event type.',
       () => {
-        const callback: AddinEventCallback = (context: any) => {
+        const callback: AddinEventCallback = () => {
           return;
         };
 

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -1,6 +1,6 @@
-import { AddinClientConfig } from './client-interfaces';
 import { AddinClientArgs } from './client-interfaces/addin-client-args';
 import { AddinClientCloseModalArgs } from './client-interfaces/addin-client-close-modal-args';
+import { AddinClientConfig } from './client-interfaces/addin-client-config';
 import { AddinClientEventArgs } from './client-interfaces/addin-client-event-args';
 import { AddinClientNavigateArgs } from './client-interfaces/addin-client-navigate-args';
 import { AddinClientOpenHelpArgs } from './client-interfaces/addin-client-open-help-args';
@@ -16,8 +16,8 @@ import { AddinHostMessage } from './host-interfaces/addin-host-message';
 import { AddinHostMessageEventData } from './host-interfaces/addin-host-message-event-data';
 
 /**
-   * Collection of regexs for our whitelist of host origins.
-   */
+  * Collection of regexs for our whitelist of host origins.
+  */
 const allowedOrigins = [
   /^https\:\/\/[\w\-\.]+\.blackbaud\.com$/,
   /^https\:\/\/[\w\-\.]+\.blackbaud\-dev\.com$/,

--- a/src/addin/client-interfaces/addin-client-args.ts
+++ b/src/addin/client-interfaces/addin-client-args.ts
@@ -1,4 +1,5 @@
 import { AddinClientCallbacks } from './addin-client-callbacks';
+import { AddinClientConfig } from './addin-client-config';
 
 /**
  * Interface for constructing an AddinClient.
@@ -10,4 +11,8 @@ export interface AddinClientArgs {
    */
   callbacks: AddinClientCallbacks;
 
+  /**
+   * Optional configuration for an AddinClient.
+   */
+  config?: AddinClientConfig;
 }

--- a/src/addin/client-interfaces/addin-client-config.ts
+++ b/src/addin/client-interfaces/addin-client-config.ts
@@ -1,0 +1,10 @@
+
+/**
+ * Configuration properties for an AddinClient.
+ */
+export interface AddinClientConfig {
+ /**
+   * Optional list of allowed origins, as RegExp, to trust as add-in hosts for this add-in client.
+   */
+  allowedOrigins?: RegExp[];
+}

--- a/src/addin/client-interfaces/index.ts
+++ b/src/addin/client-interfaces/index.ts
@@ -3,6 +3,7 @@ export * from './addin-button-style';
 export * from './addin-client-args';
 export * from './addin-client-callbacks';
 export * from './addin-client-close-modal-args';
+export * from './addin-client-config';
 export * from './addin-client-event-args';
 export * from './addin-client-flyout-permalink';
 export * from './addin-client-init-args';


### PR DESCRIPTION
Provide add-in config to allow for additional host origins

The SKY UX wrapper add-in client will be updated shortly with its implementation to support additional origins.