### PR TITLE
Remove unused box helpKey property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.5.1 (2024-10-24)
+- Removed unused `helpKey` property from the `AddinBoxConfig`
+
 # 1.5.0 (2024-10-08)
 - Added `showInlineHelp`, `helpPopoverContent`, and `helpPopoverTitle` properties in `AddinTileConfig` to support inline help in tile header.
 - Added `inlineHelpClick` callback in `AddinClientCallbacks` to handle inline help button click.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@blackbaud/sky-addin-client",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blackbaud/sky-addin-client",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/client-interfaces/addin-box-config.ts
+++ b/src/addin/client-interfaces/addin-box-config.ts
@@ -8,9 +8,4 @@ export interface AddinBoxConfig {
    * The controls to use for the box context menu
    */
   controls: AddinBoxControl[] | undefined;
-
-  /**
-   * The help key to open when the Help icon is clicked
-   */
-  helpKey?: string | undefined;
 }


### PR DESCRIPTION
Remove unused box helpKey property
- Box add-in help will eventually follow a similar implementation to the tile add-in inline help