### PR TITLE
Add opt-in modal background transparency flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,24 @@ client.showModal({
 ##### Modal add-in
 The host page will launch a full screen iframe for the URL provided, and load it as an add-in the same way it does for other types of add-ins.  The modal page must also pull in the SKY Add-in Client Library and make use of the `AddinClient`.
 
-The modal add-in will be responsible for rendering the modal element itself (including any chrome around the modal content).  To create a native modal experience, the add-in may set the body background to `transparent` and launch a SKY UX modal within its full screen iframe.
+The modal add-in will be responsible for rendering the modal element itself (including any chrome around the modal content).  To create a native modal experience, launch your modal within the full screen iframe and enable transparent modal backgrounds.
+
+Set `config.enableModalBackgroundTransparency` to `true` when constructing the client. On init it will:
+- set the iframe `body` background to `transparent`, so the host page shows through behind the modal, and
+- add a `sky-addin-modal` class to `body`, and inject a stylesheet that hides SKY UX's `.sky-modal-host-backdrop` while that class is present, so the SKY UX modal's own backdrop does not double up with the host's.
+
+This replaces manually adding `body { background: transparent }` and `.sky-modal-host-backdrop { display: none }`. The flag is off by default, so existing add-ins are unaffected.
+
+```js
+var client = new AddinClient({
+  callbacks: { /* ... */ },
+  config: {
+    enableModalBackgroundTransparency: true
+  }
+});
+```
+
+No `@skyux/modals` upgrade is required for this — backdrop suppression is implemented entirely inside `sky-addin-client` via a runtime stylesheet, not inside `@skyux/modals` itself. (Last verified against `.sky-modal-host-backdrop` in `@skyux/modals` — re-check this selector if you see the backdrop reappear after a `@skyux/modals` major-version upgrade.)
 
 As with a typical add-in, the modal add-in should register for the `init` callback and will receive `envId` in the arguments. The `context` field for arguments will match the context object passed into the `showModal` call from the parent add-in.  Note that this is crossing iframes so the object has been serialized and deserialized.  It can be used for passing data but not functions.
 

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -723,6 +723,106 @@ describe('AddinClient ', () => {
 
   });
 
+  describe('modal background transparency', () => {
+    afterEach(() => {
+      // Undo any body/head mutations so tests do not leak into each other.
+      document.body.classList.remove('sky-addin-modal');
+      document.body.style.removeProperty('background');
+      document.getElementById('sky-addin-client-modal-backdrop-style')?.remove();
+    });
+
+    function postHostReady() {
+      postMessageFromHost({
+        message: { context: {}, envId: 'e' },
+        messageType: 'host-ready',
+        source: 'bb-addin-host',
+      });
+    }
+
+    it('should set a transparent body background and marker class when opted in.', () => {
+      const client = new AddinClient({
+        callbacks: { init: () => { /* no-op */ } },
+        config: { enableModalBackgroundTransparency: true },
+      });
+
+      postHostReady();
+
+      expect(document.body.style.background).toContain('transparent');
+      expect(document.body.classList.contains('sky-addin-modal')).toBe(true);
+
+      client.destroy();
+    });
+
+    it('should NOT modify the body when the flag is not set (default).', () => {
+      const client = new AddinClient({
+        callbacks: { init: () => { /* no-op */ } },
+      });
+
+      postHostReady();
+
+      expect(document.body.style.background).not.toContain('transparent');
+      expect(document.body.classList.contains('sky-addin-modal')).toBe(false);
+
+      client.destroy();
+    });
+
+    it('should NOT modify the body when the flag is explicitly false.', () => {
+      const client = new AddinClient({
+        callbacks: { init: () => { /* no-op */ } },
+        config: { enableModalBackgroundTransparency: false },
+      });
+
+      postHostReady();
+
+      expect(document.body.classList.contains('sky-addin-modal')).toBe(false);
+
+      client.destroy();
+    });
+
+    it('should inject a stylesheet hiding .sky-modal-host-backdrop when opted in.', () => {
+      const client = new AddinClient({
+        callbacks: { init: () => { /* no-op */ } },
+        config: { enableModalBackgroundTransparency: true },
+      });
+
+      postHostReady();
+
+      const style = document.getElementById('sky-addin-client-modal-backdrop-style');
+      expect(style).not.toBeNull();
+      expect(style?.textContent).toContain('.sky-modal-host-backdrop');
+      expect(style?.textContent).toContain('display: none');
+
+      client.destroy();
+    });
+
+    it('should NOT inject any stylesheet when the flag is not set (default).', () => {
+      const client = new AddinClient({
+        callbacks: { init: () => { /* no-op */ } },
+      });
+
+      postHostReady();
+
+      expect(document.getElementById('sky-addin-client-modal-backdrop-style')).toBeNull();
+
+      client.destroy();
+    });
+
+    it('should not inject a duplicate stylesheet if host-ready fires more than once.', () => {
+      const client = new AddinClient({
+        callbacks: { init: () => { /* no-op */ } },
+        config: { enableModalBackgroundTransparency: true },
+      });
+
+      postHostReady();
+      postHostReady();
+
+      const styles = document.querySelectorAll('#sky-addin-client-modal-backdrop-style');
+      expect(styles.length).toBe(1);
+
+      client.destroy();
+    });
+  });
+
   describe('init ready callback', () => {
 
     it('should raise "addin-ready" event.',

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -148,6 +148,20 @@ export class AddinClient {
    */
   private allowedOrigins: RegExp[] = allowedOrigins;
 
+  /**
+   * Marker class added to <body> when enableModalBackgroundTransparency is set. Internal to
+   * this library — it is the selector prefix used by MODAL_BACKDROP_STYLE_ID's injected rule.
+   * It is NOT read by @skyux/modals (we intentionally do not modify that package — ADR 001).
+   */
+  private static readonly MODAL_MARKER_CLASS = 'sky-addin-modal';
+
+  /**
+   * Element id of the <style> tag this client injects into <head> when
+   * enableModalBackgroundTransparency is set. Guards against injecting a duplicate rule if
+   * host-ready fires more than once.
+   */
+  private static readonly MODAL_BACKDROP_STYLE_ID = 'sky-addin-client-modal-backdrop-style';
+
   /* istanbul ignore next */
   /**
    * @returns {string}  Returns the current query string path for the window, prefixed with ?.
@@ -513,6 +527,25 @@ export class AddinClient {
 
         // set the supported event types (default to empty array)
         this.supportedEventTypes = data.message.supportedEventTypes || [];
+
+        // Opt-in: make the iframe body transparent, stamp a marker class, and inject a
+        // stylesheet that hides @skyux/modals's own backdrop while that marker is present —
+        // so the host's backdrop shows through and no doubled scrim appears. Off by default;
+        // existing add-ins are unaffected. We deliberately do NOT modify @skyux/modals to
+        // achieve this (ADR 001) — `.sky-modal-host-backdrop` is that package's internal
+        // implementation detail, not a published contract, so re-verify this selector if
+        // @skyux/modals ever changes its backdrop markup/class name.
+        if (this.args.config?.enableModalBackgroundTransparency) {
+          document.body.style.background = 'transparent';
+          document.body.classList.add(AddinClient.MODAL_MARKER_CLASS);
+
+          if (!document.getElementById(AddinClient.MODAL_BACKDROP_STYLE_ID)) {
+            const style = document.createElement('style');
+            style.id = AddinClient.MODAL_BACKDROP_STYLE_ID;
+            style.textContent = `body.${AddinClient.MODAL_MARKER_CLASS} .sky-modal-host-backdrop { display: none !important; }`;
+            document.head.appendChild(style);
+          }
+        }
 
         // Pass key data to the add-in for it to initiailze.
         this.args.callbacks.init({

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -536,13 +536,27 @@ export class AddinClient {
         // implementation detail, not a published contract, so re-verify this selector if
         // @skyux/modals ever changes its backdrop markup/class name.
         if (this.args.config?.enableModalBackgroundTransparency) {
+          // Make the iframe's body transparent so the host page shows through behind the modal
+          // instead of being painted over by the add-in's own opaque body.
           document.body.style.background = 'transparent';
+
+          // Stamp the marker class on <body>; the injected stylesheet below scopes its rule to
+          // this class so the suppression only applies while the opted-in add-in is active.
           document.body.classList.add(AddinClient.MODAL_MARKER_CLASS);
 
+          // Inject the backdrop-suppression stylesheet only once. host-ready can fire more than
+          // once, and the id check prevents appending duplicate <style> elements to <head>.
           if (!document.getElementById(AddinClient.MODAL_BACKDROP_STYLE_ID)) {
+            // Build a <style> element identified by our constant id so we can dedupe (above).
             const style = document.createElement('style');
             style.id = AddinClient.MODAL_BACKDROP_STYLE_ID;
+
+            // Hide @skyux/modals's own backdrop while the marker class is present, so it does
+            // not double up with the host's scrim. The two-class selector plus !important gives
+            // this rule enough specificity to win from outside @skyux/modals's own stylesheet.
             style.textContent = `body.${AddinClient.MODAL_MARKER_CLASS} .sky-modal-host-backdrop { display: none !important; }`;
+
+            // Append to <head> so the rule takes effect for the current document.
             document.head.appendChild(style);
           }
         }

--- a/src/addin/client-interfaces/addin-client-config.ts
+++ b/src/addin/client-interfaces/addin-client-config.ts
@@ -7,4 +7,13 @@ export interface AddinClientConfig {
    * Optional list of allowed origins, as RegExp, to trust as add-in hosts for this add-in client.
    */
   allowedOrigins?: RegExp[];
+
+  /**
+   * When true, the client makes the add-in's body background transparent and adds a
+   * `sky-addin-modal` marker class to the document body when the add-in initializes.
+   * Use this for modal add-ins so the host page shows through behind the modal and the
+   * SKY UX modal backdrop does not double up with the host's. Off by default so existing
+   * add-ins are unaffected.
+   */
+  enableModalBackgroundTransparency?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds an opt-in `enableModalBackgroundTransparency` flag to `AddinClientConfig`, off by default so existing add-ins are unaffected.
- When set, the client makes the iframe `body` background transparent, adds a `sky-addin-modal` marker class, and injects a `<style>` rule hiding SKY UX's `.sky-modal-host-backdrop` — replacing the copy-pasted CSS workaround developers have historically needed.
- No changes to `@skyux/modals` — backdrop suppression is implemented entirely in this package via a runtime-injected stylesheet (see ADR 001 in `sky-api-plans/plans/addin-modal-transparent-background/adr/001-no-skyux-modals-changes.md`).
- Documents the flag and mechanism in the README's "Modal add-in" section.

Implements Tasks 1–3 of the plan at `Products/sky-api-plans` → `plans/addin-modal-transparent-background/implementation-plan.md`. Tasks 4–5 (demo app, wrapper verification) live in other repos and are out of scope here.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run test:unit` — 155/155 passing, including 6 new specs covering opt-in on/off/false and stylesheet injection/dedup
- [x] `npm run lint` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to enable transparent modal backgrounds for modal add-ins.
  * When enabled, the modal background becomes transparent and the add-in marks the page to suppress the underlying modal backdrop.
  * Includes safeguards to avoid duplicate backdrop-styling injections.

* **Documentation**
  * Updated modal add-in guidance with the new configuration option, default behavior, and examples.

* **Tests**
  * Added coverage for enabled/disabled behavior, stylesheet injection, and prevention of duplicate styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->