### PR TITLE
Add-in modal background styling options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.8.0 (2026-08-04)
 
 - Add independent modal body-transparency and host-overlay style options.
-- Forward optional modal display context without selecting style defaults.
+- Forward optional canonical `addinType` identifying how the host displays the add-in, without selecting style defaults.
 
 # 1.7.3 (2026-03-24)
 - Updated `allowedOrigins` to support Luminate Online on T60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.8.0
+# 1.8.0 (2026-08-04)
 
 - Add independent modal body-transparency and host-overlay style options.
 - Forward optional modal display context without selecting style defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.8.0
+
+- Add independent modal body-transparency and host-overlay style options.
+- Forward optional modal display context without selecting style defaults.
+
 # 1.7.3 (2026-03-24)
 - Updated `allowedOrigins` to support Luminate Online on T60
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.8.0 (2026-08-04)
 
 - Add independent modal body-transparency and host-overlay style options.
-- Forward optional canonical `addinType` identifying how the host displays the add-in, without selecting style defaults.
+- Forward canonical `addinType` identifying how the host displays the add-in, without selecting style defaults.
 
 # 1.7.3 (2026-03-24)
 - Updated `allowedOrigins` to support Luminate Online on T60

--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ overlay through `modalConfig.style`:
 |---|---|
 | `transparentBackground: true` | Makes the add-in document body transparent before `addin-ready`. |
 | `transparentBackground: false` or omitted | Does not make the body transparent. |
-| `hostOverlay: false` | Asks a compatible host to retain its overlay element but make the overlay background transparent. |
-| `hostOverlay: true` or omitted | Retains the compatible host's visible overlay. |
+| `hostOverlay: false` | Asks a compatible host to make its overlay background transparent while keeping the overlay element. |
+| `hostOverlay: true` or omitted | Asks a compatible host to retain its visible overlay. |
 
 These options are independent and this library does not default them.
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ The modal add-in can independently configure its document body and a host's over
 | Option | Behavior |
 |---|---|
 | `transparentBackground: true` | Makes the add-in document body transparent. |
-| `transparentBackground: false` or omitted | Does not make the body transparent. |
+| `transparentBackground: false` or omitted | Retains add-in's body styling. |
 | `hostOverlay: false` | Hides the host's modal overlay. |
 | `hostOverlay: true` or omitted | Host retain its modal visible overlay. |
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All add-ins must use this library in order to show in the host application. You 
 Your `init` function will be called with an arguments object that contains:
  - `envId` - The environment ID for the host page
  - `context` - Additional context of the host page, which will vary for different extension points.
+ - `addinType` - Optional. Identifies the canonical pattern in which the host is displaying the add-in (one of `'action-button'`, `'box'`, `'button'`, `'dataset'`, `'flyout'`, `'generic'`, `'modal'`, `'page'`, `'tab'`, `'tile'`, or `'vertical-tab'`). Not every host populates this value, so it may be `undefined`; this library never assumes a default. Because each iframe re-establishes its own `init` handshake, a modal or flyout add-in receives its own `addinType` on that fresh handshake rather than inheriting the value seen by the add-in that launched it.
  - `supportedEventTypes` - The supported event types that are handled by the host page.
  - `themeSettings` - The UX theme of the host page.
  - `ready` - A callback to inform the add-in client that the add-in is initialized and ready to be shown.
@@ -298,7 +299,7 @@ args.ready({
 
 Older hosts ignore `hostOverlay` and retain their visible overlay.
 
-As with a typical add-in, the modal add-in should register for the `init` callback and will receive `envId` in the arguments. The `context` field for arguments will match the context object passed into the `showModal` call from the parent add-in.  Note that this is crossing iframes so the object has been serialized and deserialized.  It can be used for passing data but not functions.
+As with a typical add-in, the modal add-in should register for the `init` callback and will receive `envId` in the arguments. The `context` field for arguments will match the context object passed into the `showModal` call from the parent add-in.  Note that this is crossing iframes so the object has been serialized and deserialized.  It can be used for passing data but not functions.  A compatible host reports `addinType: 'modal'` on this fresh `init` handshake, though the modal add-in should not assume it and should treat `addinType` as optional.
 
 ##### Closing the modal
 The modal add-in is responsible for triggering the close with the `closeModal` function on the client.  It is able to pass context information back to the parent add-in:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All add-ins must use this library in order to show in the host application. You 
 Your `init` function will be called with an arguments object that contains:
  - `envId` - The environment ID for the host page
  - `context` - Additional context of the host page, which will vary for different extension points.
- - `addinType` - Optional. Identifies the canonical pattern in which the host is displaying the add-in (one of `'action-button'`, `'box'`, `'button'`, `'dataset'`, `'flyout'`, `'generic'`, `'modal'`, `'page'`, `'tab'`, `'tile'`, or `'vertical-tab'`). Not every host populates this value, so it may be `undefined`; this library never assumes a default. Because each iframe re-establishes its own `init` handshake, a modal or flyout add-in receives its own `addinType` on that fresh handshake rather than inheriting the value seen by the add-in that launched it.
+ - `addinType` (Version 1.8+) - Identifies the host's display mode for the add-in (`'action-button'`, `'box'`, `'button'`, `'dataset'`, `'flyout'`, `'generic'`, `'modal'`, `'page'`, `'tab'`, `'tile'`, or `'vertical-tab'`). Useful when your add-in is used in multiple display modes.
  - `supportedEventTypes` - The supported event types that are handled by the host page.
  - `themeSettings` - The UX theme of the host page.
  - `ready` - A callback to inform the add-in client that the add-in is initialized and ready to be shown.
@@ -273,15 +273,14 @@ client.showModal({
 ##### Modal add-in
 The host page will launch a full screen iframe for the URL provided, and load it as an add-in the same way it does for other types of add-ins.  The modal page must also pull in the SKY Add-in Client Library and make use of the `AddinClient`.
 
-The modal add-in can independently configure its document body and a compatible host's
-overlay through `modalConfig.style`:
+The modal add-in can independently configure its document body and a host's overlay through `modalConfig.style`:
 
 | Option | Behavior |
 |---|---|
-| `transparentBackground: true` | Makes the add-in document body transparent before `addin-ready`. |
+| `transparentBackground: true` | Makes the add-in document body transparent. |
 | `transparentBackground: false` or omitted | Does not make the body transparent. |
-| `hostOverlay: false` | Asks a compatible host to make its overlay background transparent while keeping the overlay element. |
-| `hostOverlay: true` or omitted | Asks a compatible host to retain its visible overlay. |
+| `hostOverlay: false` | Hides the host's modal overlay. |
+| `hostOverlay: true` or omitted | Host retain its modal visible overlay. |
 
 These options are independent and this library does not default them.
 
@@ -296,10 +295,6 @@ args.ready({
   }
 });
 ```
-
-Older hosts ignore `hostOverlay` and retain their visible overlay.
-
-As with a typical add-in, the modal add-in should register for the `init` callback and will receive `envId` in the arguments. The `context` field for arguments will match the context object passed into the `showModal` call from the parent add-in.  Note that this is crossing iframes so the object has been serialized and deserialized.  It can be used for passing data but not functions.  A compatible host reports `addinType: 'modal'` on this fresh `init` handshake, though the modal add-in should not assume it and should treat `addinType` as optional.
 
 ##### Closing the modal
 The modal add-in is responsible for triggering the close with the `closeModal` function on the client.  It is able to pass context information back to the parent add-in:

--- a/README.md
+++ b/README.md
@@ -272,7 +272,31 @@ client.showModal({
 ##### Modal add-in
 The host page will launch a full screen iframe for the URL provided, and load it as an add-in the same way it does for other types of add-ins.  The modal page must also pull in the SKY Add-in Client Library and make use of the `AddinClient`.
 
-The modal add-in will be responsible for rendering the modal element itself (including any chrome around the modal content).  To create a native modal experience, the add-in may set the body background to `transparent` and launch a SKY UX modal within its full screen iframe.
+The modal add-in can independently configure its document body and a compatible host's
+overlay through `modalConfig.style`:
+
+| Option | Behavior |
+|---|---|
+| `transparentBackground: true` | Makes the add-in document body transparent before `addin-ready`. |
+| `transparentBackground: false` or omitted | Does not make the body transparent. |
+| `hostOverlay: false` | Asks a compatible host to retain its overlay element but make the overlay background transparent. |
+| `hostOverlay: true` or omitted | Retains the compatible host's visible overlay. |
+
+These options are independent and this library does not default them.
+
+```js
+args.ready({
+  showUI: true,
+  modalConfig: {
+    style: {
+      transparentBackground: true,
+      hostOverlay: false
+    }
+  }
+});
+```
+
+Older hosts ignore `hostOverlay` and retain their visible overlay.
 
 As with a typical add-in, the modal add-in should register for the `init` callback and will receive `envId` in the arguments. The `context` field for arguments will match the context object passed into the `showModal` call from the parent add-in.  Note that this is crossing iframes so the object has been serialized and deserialized.  It can be used for passing data but not functions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blackbaud/sky-addin-client",
-      "version": "1.7.2",
+      "version": "1.8.0",
       "license": "MIT",
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/sky-addin-client",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "SKY add-in client",
   "main": "dist/bundles/sky-addin-client.umd.js",
   "module": "index.ts",

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -761,6 +761,46 @@ describe('AddinClient ', () => {
         expect(postedOrigin).toBe(TEST_HOST_ORIGIN);
       });
 
+    it('should pass hostOverlay: false through to the host in the "addin-ready" message.',
+      () => {
+        const readyArgs: AddinClientReadyArgs = {
+          modalConfig: {
+            style: {
+              hostOverlay: false
+            }
+          }
+        };
+        let postedMessage: any;
+        let postedOrigin: string;
+
+        const client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready(readyArgs);
+            }
+          }
+        });
+
+        const msg: AddinHostMessageEventData = {
+          message: {},
+          messageType: 'host-ready',
+          source: 'bb-addin-host'
+        };
+
+        spyOn(window.parent, 'postMessage').and.callFake((message, targetOrigin) => {
+          postedMessage = message;
+          postedOrigin = targetOrigin as string;
+        });
+
+        postMessageFromHost(msg);
+
+        client.destroy();
+
+        expect(postedMessage.messageType).toBe('addin-ready');
+        expect(postedMessage.message).toEqual(readyArgs);
+        expect(postedOrigin).toBe(TEST_HOST_ORIGIN);
+      });
+
   });
 
   describe('closeModal', () => {

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -190,6 +190,7 @@ describe('AddinClient ', () => {
           const msg: AddinHostMessageEventData = {
             message: {
               context: 'my_context',
+              displayMode: 'modal',
               envId: 'my_envid',
               supportedEventTypes: ['update-event'],
               themeSettings: {
@@ -207,6 +208,7 @@ describe('AddinClient ', () => {
           client.destroy();
 
           expect(initArgs.context).toBe('my_context');
+          expect(initArgs.displayMode).toBe('modal');
           expect(initArgs.envId).toBe('my_envid');
           expect(initArgs.supportedEventTypes).toEqual(['update-event']);
           expect(initArgs.themeSettings).toEqual({

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -917,7 +917,7 @@ describe('AddinClient ', () => {
             init: (args: AddinClientInitArgs) => {
               args.ready({
                 modalConfig: {
-                  style: { hostOverlay: false } as any
+                  style: { hostOverlay: false }
                 }
               });
             }

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -14,6 +14,8 @@ import { AddinToastStyle } from './client-interfaces/addin-toast-style';
 import { AddinHostMessageEventData } from './host-interfaces/addin-host-message-event-data';
 
 const TEST_HOST_ORIGIN = 'https://host.nxt.blackbaud.com';
+const TRANSPARENT_BACKGROUND_CLASS = 'bb-sky-addin-client-transparent-background';
+const TRANSPARENT_BACKGROUND_STYLE_ID = 'bb-sky-addin-client-transparent-background-style';
 
 function postMessageFromHost(msg: AddinHostMessageEventData, origin?: string) {
   if (!origin) { origin = TEST_HOST_ORIGIN; }
@@ -800,6 +802,373 @@ describe('AddinClient ', () => {
         expect(postedMessage.message).toEqual(readyArgs);
         expect(postedOrigin).toBe(TEST_HOST_ORIGIN);
       });
+
+    describe('modal body transparency', () => {
+      const opaqueBackground = 'rgb(1, 2, 3)';
+      let bodyClassesAddedByTest: string[];
+      let client: AddinClient;
+      let originalBodyBackgroundColor: string;
+      let originalBodyColor: string;
+      let styleElementsAddedByTest: HTMLStyleElement[];
+
+      function addBodyClassForTest(className: string) {
+        if (!document.body.classList.contains(className)) {
+          document.body.classList.add(className);
+          bodyClassesAddedByTest.push(className);
+        }
+      }
+
+      beforeEach(() => {
+        bodyClassesAddedByTest = [];
+        client = undefined;
+        originalBodyBackgroundColor = document.body.style.backgroundColor;
+        originalBodyColor = document.body.style.color;
+        styleElementsAddedByTest = [];
+        document.body.style.backgroundColor = opaqueBackground;
+      });
+
+      afterEach(() => {
+        if (client) {
+          client.destroy();
+        }
+
+        styleElementsAddedByTest.forEach((style) => style.parentNode?.removeChild(style));
+
+        bodyClassesAddedByTest.forEach((className) => {
+          document.body.classList.remove(className);
+        });
+        document.body.style.backgroundColor = originalBodyBackgroundColor;
+        document.body.style.color = originalBodyColor;
+      });
+
+      it('should preserve the body background when no modalConfig is provided.', () => {
+        const initialBackground = window.getComputedStyle(document.body).backgroundColor;
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready({});
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+        expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+        expect(window.getComputedStyle(document.body).backgroundColor).toBe(initialBackground);
+      });
+
+      it('should preserve the body background when style is an empty object.', () => {
+        const initialBackground = window.getComputedStyle(document.body).backgroundColor;
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready({
+                modalConfig: {
+                  style: {}
+                }
+              });
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+        expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+        expect(window.getComputedStyle(document.body).backgroundColor).toBe(initialBackground);
+      });
+
+      it('should preserve the body background when transparentBackground is false.', () => {
+        const initialBackground = window.getComputedStyle(document.body).backgroundColor;
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready({
+                modalConfig: {
+                  style: { transparentBackground: false }
+                }
+              });
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+        expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+        expect(window.getComputedStyle(document.body).backgroundColor).toBe(initialBackground);
+      });
+
+      it('should preserve the body background when only hostOverlay is false.', () => {
+        const initialBackground = window.getComputedStyle(document.body).backgroundColor;
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready({
+                modalConfig: {
+                  style: { hostOverlay: false } as any
+                }
+              });
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+        expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+        expect(window.getComputedStyle(document.body).backgroundColor).toBe(initialBackground);
+      });
+
+      it('should make the body transparent before checking height and posting "addin-ready" when transparentBackground is true.',
+        () => {
+          const transparentBackground = true;
+          let backgroundAtHeightCheck: string;
+          let backgroundAtAddinReady: string;
+
+          client = new AddinClient({
+            callbacks: {
+              init: (args: AddinClientInitArgs) => {
+                args.ready({
+                  modalConfig: {
+                    style: { transparentBackground }
+                  }
+                });
+              }
+            }
+          });
+
+          const clientPrivateApi = client as unknown as {
+            checkForHeightChangesOfAddinContent(): void;
+          };
+          const heightCheckSpy = spyOn(
+            clientPrivateApi,
+            'checkForHeightChangesOfAddinContent'
+          ).and.callFake(() => {
+            backgroundAtHeightCheck = window.getComputedStyle(document.body).backgroundColor;
+          });
+
+          spyOn(window.parent, 'postMessage').and.callFake((message) => {
+            if (message.messageType === 'addin-ready') {
+              backgroundAtAddinReady = window.getComputedStyle(document.body).backgroundColor;
+            }
+          });
+
+          initializeHost();
+
+          expect(heightCheckSpy).toHaveBeenCalled();
+          expect(backgroundAtHeightCheck).toBe('rgba(0, 0, 0, 0)');
+          expect(backgroundAtAddinReady).toBe('rgba(0, 0, 0, 0)');
+          expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(true);
+          expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).not.toBeNull();
+        });
+
+      it('should preserve an unrelated style when the stable transparent style ID is occupied.', () => {
+        const unrelatedStyle = document.createElement('style');
+        unrelatedStyle.id = TRANSPARENT_BACKGROUND_STYLE_ID;
+        unrelatedStyle.textContent = '.unrelated-style { color: rgb(4, 5, 6); }';
+        document.head.appendChild(unrelatedStyle);
+        styleElementsAddedByTest.push(unrelatedStyle);
+        const unrelatedStyleMarkup = unrelatedStyle.outerHTML;
+        const styleElementsBeforeClient = Array.from(document.head.querySelectorAll('style'));
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready({
+                modalConfig: {
+                  style: { transparentBackground: true }
+                }
+              });
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+
+        const clientStyle = Array.from(document.head.querySelectorAll('style'))
+          .find((style) => styleElementsBeforeClient.indexOf(style) === -1);
+
+        expect(document.querySelectorAll(`[id="${TRANSPARENT_BACKGROUND_STYLE_ID}"]`).length)
+          .toBe(1);
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(true);
+        expect(window.getComputedStyle(document.body).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+
+        client.destroy();
+        client = undefined;
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+        expect(clientStyle?.parentNode).toBeNull();
+        expect(unrelatedStyle.parentNode).toBe(document.head);
+        expect(unrelatedStyle.outerHTML).toBe(unrelatedStyleMarkup);
+      });
+
+      it('should preserve a transparent background class that predates the client.', () => {
+        addBodyClassForTest(TRANSPARENT_BACKGROUND_CLASS);
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready({
+                modalConfig: {
+                  style: { transparentBackground: true }
+                }
+              });
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+        client.destroy();
+        client = undefined;
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(true);
+        expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+      });
+
+      it('should reuse the client-owned style when ready is called repeatedly.', () => {
+        let ready: (args: AddinClientReadyArgs) => void;
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              ready = args.ready;
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+        ready({
+          modalConfig: {
+            style: { transparentBackground: true }
+          }
+        });
+        ready({
+          modalConfig: {
+            style: { transparentBackground: true }
+          }
+        });
+
+        expect(document.querySelectorAll(`#${TRANSPARENT_BACKGROUND_STYLE_ID}`).length).toBe(1);
+      });
+
+      it('should remove stale client-owned transparency when a later ready call preserves the background.',
+        () => {
+          let ready: (args: AddinClientReadyArgs) => void;
+
+          client = new AddinClient({
+            callbacks: {
+              init: (args: AddinClientInitArgs) => {
+                ready = args.ready;
+              }
+            }
+          });
+
+          spyOn(window.parent, 'postMessage').and.stub();
+
+          initializeHost();
+          ready({
+            modalConfig: {
+              style: { transparentBackground: true }
+            }
+          });
+
+          expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(true);
+
+          ready({
+            modalConfig: {
+              style: { transparentBackground: false }
+            }
+          });
+
+          expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+          expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+          expect(window.getComputedStyle(document.body).backgroundColor).toBe(opaqueBackground);
+        });
+
+      it('should remove stale client-owned transparency when a later ready call omits the background mode.',
+        () => {
+          let ready: (args: AddinClientReadyArgs) => void;
+
+          client = new AddinClient({
+            callbacks: {
+              init: (args: AddinClientInitArgs) => {
+                ready = args.ready;
+              }
+            }
+          });
+
+          spyOn(window.parent, 'postMessage').and.stub();
+
+          initializeHost();
+          ready({
+            modalConfig: {
+              style: { transparentBackground: true }
+            }
+          });
+
+          expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(true);
+
+          ready({});
+
+          expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+          expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+          expect(window.getComputedStyle(document.body).backgroundColor).toBe(opaqueBackground);
+        });
+
+      it('should remove only client-owned body state on destroy.', () => {
+        const unrelatedClass = 'unrelated-body-class';
+        const unrelatedColor = 'rgb(4, 5, 6)';
+        addBodyClassForTest(unrelatedClass);
+        document.body.style.color = unrelatedColor;
+
+        client = new AddinClient({
+          callbacks: {
+            init: (args: AddinClientInitArgs) => {
+              args.ready({
+                modalConfig: {
+                  style: { transparentBackground: true }
+                }
+              });
+            }
+          }
+        });
+
+        spyOn(window.parent, 'postMessage').and.stub();
+
+        initializeHost();
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(true);
+        expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).not.toBeNull();
+
+        client.destroy();
+
+        expect(document.body.classList.contains(TRANSPARENT_BACKGROUND_CLASS)).toBe(false);
+        expect(document.getElementById(TRANSPARENT_BACKGROUND_STYLE_ID)).toBeNull();
+        expect(document.body.classList.contains(unrelatedClass)).toBe(true);
+        expect(document.body.style.backgroundColor).toBe(opaqueBackground);
+        expect(document.body.style.color).toBe(unrelatedColor);
+      });
+    });
 
   });
 

--- a/src/addin/addin-client.spec.ts
+++ b/src/addin/addin-client.spec.ts
@@ -191,8 +191,8 @@ describe('AddinClient ', () => {
 
           const msg: AddinHostMessageEventData = {
             message: {
+              addinType: 'tile',
               context: 'my_context',
-              displayMode: 'modal',
               envId: 'my_envid',
               supportedEventTypes: ['update-event'],
               themeSettings: {
@@ -209,8 +209,8 @@ describe('AddinClient ', () => {
 
           client.destroy();
 
+          expect(initArgs.addinType).toBe('tile');
           expect(initArgs.context).toBe('my_context');
-          expect(initArgs.displayMode).toBe('modal');
           expect(initArgs.envId).toBe('my_envid');
           expect(initArgs.supportedEventTypes).toEqual(['update-event']);
           expect(initArgs.themeSettings).toEqual({
@@ -218,6 +218,34 @@ describe('AddinClient ', () => {
             theme: 'default',
             skyThemeSettings: '{"theme":{"name":"modern","supportedModes":[{"name":"default","isPreset":true}],"isPreset":true},"mode":{"name":"light","isPreset":true}}'
           });
+        });
+
+      it('should leave "addinType" undefined when the host does not provide it.',
+        () => {
+          let initArgs: any;
+
+          const client = new AddinClient({
+            callbacks: {
+              init: (args: AddinClientInitArgs) => {
+                initArgs = args;
+              }
+            }
+          });
+
+          const msg: AddinHostMessageEventData = {
+            message: {
+              context: 'my_context',
+              envId: 'my_envid'
+            },
+            messageType: 'host-ready',
+            source: 'bb-addin-host'
+          };
+
+          postMessageFromHost(msg);
+
+          client.destroy();
+
+          expect(initArgs.addinType).toBeUndefined();
         });
 
     });

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -163,7 +163,7 @@ export class AddinClient {
   /**
    * The transparent background style element created by this client.
    */
-  private transparentBackgroundStyleElement: HTMLStyleElement;
+  private transparentBackgroundStyleElement: HTMLStyleElement | undefined;
 
   /**
    * Collection of regexs for our whitelist of host origins.

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -12,6 +12,7 @@ import { AddinClientShowFlyoutResult } from './client-interfaces/addin-client-sh
 import { AddinClientShowModalArgs } from './client-interfaces/addin-client-show-modal-args';
 import { AddinClientShowModalResult } from './client-interfaces/addin-client-show-modal-result';
 import { AddinClientShowToastArgs } from './client-interfaces/addin-client-show-toast-args';
+import { AddinModalConfig } from './client-interfaces/addin-modal-config';
 import { AddinHostMessage } from './host-interfaces/addin-host-message';
 import { AddinHostMessageEventData } from './host-interfaces/addin-host-message-event-data';
 
@@ -144,6 +145,27 @@ export class AddinClient {
   private supportedEventTypes: string[] = [];
 
   /**
+   * Class added to the body when the client owns its transparent background state.
+   */
+  private readonly transparentBackgroundClass = 'bb-sky-addin-client-transparent-background';
+
+  /**
+   * Preferred ID for the client-owned transparent background style.
+   */
+  private readonly transparentBackgroundStyleId =
+    'bb-sky-addin-client-transparent-background-style';
+
+  /**
+   * Indicates whether this client added the transparent background class.
+   */
+  private ownsTransparentBackgroundClass = false;
+
+  /**
+   * The transparent background style element created by this client.
+   */
+  private transparentBackgroundStyleElement: HTMLStyleElement;
+
+  /**
    * Collection of regexs for our whitelist of host origins.
    */
   private allowedOrigins: RegExp[] = allowedOrigins;
@@ -179,6 +201,8 @@ export class AddinClient {
     if (this.heightChangeIntervalId) {
       clearInterval(this.heightChangeIntervalId);
     }
+
+    this.cleanupTransparentBackground();
   }
 
   /**
@@ -439,6 +463,51 @@ export class AddinClient {
   }
 
   /**
+   * Applies the client-owned document body transparency for a modal add-in.
+   * @param style The modal style from the ready args.
+   */
+  private applyModalStyle(style: AddinModalConfig['style']) {
+    if (style?.transparentBackground !== true) {
+      this.cleanupTransparentBackground();
+      return;
+    }
+
+    if (!document.body.classList.contains(this.transparentBackgroundClass)) {
+      document.body.classList.add(this.transparentBackgroundClass);
+      this.ownsTransparentBackgroundClass = true;
+    }
+
+    if (!this.transparentBackgroundStyleElement?.parentNode) {
+      const styleElement = document.createElement('style');
+      if (!document.getElementById(this.transparentBackgroundStyleId)) {
+        styleElement.id = this.transparentBackgroundStyleId;
+      }
+      styleElement.textContent =
+        `body.${this.transparentBackgroundClass} ` +
+        '{ background: transparent !important; }';
+      document.head.appendChild(styleElement);
+      this.transparentBackgroundStyleElement = styleElement;
+    }
+  }
+
+  /**
+   * Removes document body background state owned by this client.
+   */
+  private cleanupTransparentBackground() {
+    if (this.ownsTransparentBackgroundClass) {
+      document.body.classList.remove(this.transparentBackgroundClass);
+      this.ownsTransparentBackgroundClass = false;
+    }
+
+    if (this.transparentBackgroundStyleElement?.parentNode) {
+      this.transparentBackgroundStyleElement.parentNode.removeChild(
+        this.transparentBackgroundStyleElement
+      );
+    }
+    this.transparentBackgroundStyleElement = undefined;
+  }
+
+  /**
    * Post a message to the host page informing it that the add-in is
    * now started and listening for messages from the host.
    */
@@ -520,6 +589,8 @@ export class AddinClient {
           displayMode: data.message.displayMode,
           envId: data.message.envId,
           ready: (args: AddinClientReadyArgs) => {
+            this.applyModalStyle(args?.modalConfig?.style);
+
             // Do an immediate height check since the add-in may render something
             // due to the context provided.  No need to wait a full second to reflect.
             this.checkForHeightChangesOfAddinContent();

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -585,8 +585,8 @@ export class AddinClient {
 
         // Pass key data to the add-in for it to initiailze.
         this.args.callbacks.init({
+          addinType: data.message.addinType,
           context: data.message.context,
-          displayMode: data.message.displayMode,
           envId: data.message.envId,
           ready: (args: AddinClientReadyArgs) => {
             this.applyModalStyle(args?.modalConfig?.style);

--- a/src/addin/addin-client.ts
+++ b/src/addin/addin-client.ts
@@ -517,6 +517,7 @@ export class AddinClient {
         // Pass key data to the add-in for it to initiailze.
         this.args.callbacks.init({
           context: data.message.context,
+          displayMode: data.message.displayMode,
           envId: data.message.envId,
           ready: (args: AddinClientReadyArgs) => {
             // Do an immediate height check since the add-in may render something

--- a/src/addin/client-interfaces/addin-client-init-args.ts
+++ b/src/addin/client-interfaces/addin-client-init-args.ts
@@ -17,6 +17,11 @@ export interface AddinClientInitArgs {
   context?: any;
 
   /**
+   * Identifies how the host is displaying this add-in.
+   */
+  displayMode?: 'modal';
+
+  /**
    * Event types that are supported by the host page.
    */
    supportedEventTypes?: string[];

--- a/src/addin/client-interfaces/addin-client-init-args.ts
+++ b/src/addin/client-interfaces/addin-client-init-args.ts
@@ -1,5 +1,6 @@
 import { AddinClientReadyArgs } from './addin-client-ready-args';
 import { AddinClientThemeSettings } from './addin-client-theme-settings';
+import { AddinType } from './addin-type';
 
 /**
  * Interface for contextual information that will be provided in the init callback.
@@ -17,9 +18,9 @@ export interface AddinClientInitArgs {
   context?: any;
 
   /**
-   * Identifies how the host is displaying this add-in.
+   * Identifies the canonical pattern in which the host displays the add-in.
    */
-  displayMode?: 'modal';
+  addinType?: AddinType;
 
   /**
    * Event types that are supported by the host page.

--- a/src/addin/client-interfaces/addin-modal-config.ts
+++ b/src/addin/client-interfaces/addin-modal-config.ts
@@ -9,7 +9,10 @@ export interface AddinModalStyle {
   transparentBackground?: boolean;
 
   /**
+   * Controls the host overlay appearance.
+   *
    * When false, asks a compatible host to make its overlay transparent.
+   * When true or omitted, the host retains its visible overlay.
    */
   hostOverlay?: boolean;
 }

--- a/src/addin/client-interfaces/addin-modal-config.ts
+++ b/src/addin/client-interfaces/addin-modal-config.ts
@@ -1,4 +1,20 @@
 /**
+ * Controls independent modal body and host-overlay styling.
+ */
+export interface AddinModalStyle {
+
+  /**
+   * When true, makes the add-in document body transparent.
+   */
+  transparentBackground?: boolean;
+
+  /**
+   * When false, asks a compatible host to make its overlay transparent.
+   */
+  hostOverlay?: boolean;
+}
+
+/**
  * Interface for defining configuration options for Modal add-ins
  */
 export interface AddinModalConfig {
@@ -10,4 +26,9 @@ export interface AddinModalConfig {
    * appropriately for a full-page modal.
    */
   fullPage?: boolean;
+
+  /**
+   * Controls independent modal body and host-overlay styling.
+   */
+  style?: AddinModalStyle;
 }

--- a/src/addin/client-interfaces/addin-type.ts
+++ b/src/addin/client-interfaces/addin-type.ts
@@ -1,0 +1,15 @@
+/**
+ * Identifies the canonical pattern in which the host displays an add-in.
+ */
+export type AddinType =
+  'action-button' |
+  'box' |
+  'button' |
+  'dataset' |
+  'flyout' |
+  'generic' |
+  'modal' |
+  'page' |
+  'tab' |
+  'tile' |
+  'vertical-tab';

--- a/src/addin/client-interfaces/index.ts
+++ b/src/addin/client-interfaces/index.ts
@@ -28,3 +28,4 @@ export * from './addin-tab-summary-style';
 export * from './addin-tile-config';
 export * from './addin-tile-summary-style';
 export * from './addin-toast-style';
+export * from './addin-type';

--- a/src/addin/host-interfaces/addin-host-message.ts
+++ b/src/addin/host-interfaces/addin-host-message.ts
@@ -22,6 +22,11 @@ export interface AddinHostMessage {
   context?: any;
 
   /**
+   * Identifies how the host is displaying this add-in.
+   */
+  displayMode?: 'modal';
+
+  /**
    * The environment id of the host page.
    */
   envId?: string;

--- a/src/addin/host-interfaces/addin-host-message.ts
+++ b/src/addin/host-interfaces/addin-host-message.ts
@@ -1,4 +1,4 @@
-import { AddinClientThemeSettings } from '../client-interfaces';
+import { AddinClientThemeSettings, AddinType } from '../client-interfaces';
 
 /**
  * Interface for the actual message data embedded in an AddinHostMessageEventData.
@@ -22,9 +22,9 @@ export interface AddinHostMessage {
   context?: any;
 
   /**
-   * Identifies how the host is displaying this add-in.
+   * Identifies the canonical pattern in which the host displays the add-in.
    */
-  displayMode?: 'modal';
+  addinType?: AddinType;
 
   /**
    * The environment id of the host page.


### PR DESCRIPTION
## Summary

This PR adds independent modal styling options and canonical add-in type context to `@blackbaud/sky-addin-client` 1.8.0.

These changes allow add-ins to coordinate their document background and host’s modal overlay without framework-specific CSS workarounds. Existing add-ins retain their current rendering unless they explicitly opt into the new style options.

## What changed

### Independent modal style options

Adds `modalConfig.style` with two independent options:

| Option | Behavior |
|---|---|
| `transparentBackground: true` | Makes the add-in document body transparent. |
| `transparentBackground: false` or omitted | Retains add-in's body styling. |
| `hostOverlay: false` | Hides the host's modal overlay. |
| `hostOverlay: true` or omitted | Host retain its modal visible overlay. |

The base client owns only document-body transparency. It forwards `hostOverlay` to the host without inferring or combining the two options.

### Canonical add-in type context

Adds the canonical `AddinType` contract:

`action-button`, `box`, `button`, `dataset`, `flyout`, `generic`, `modal`, `page`, `tab`, `tile`, and `vertical-tab`.

The host provides `addinType` through the `init` callback so an add-in can determine how it is being displayed.

## What this enables
```js
args.ready({ showUI: true, modalConfig: {
    style: {
      transparentBackground: true,
      hostOverlay: false
    } }
});
```

This allows the add-in body and host overlay to become transparent while a UI framework such as SKY UX retains its normal modal backdrop as the single visible backgrop.

The canonical  `addinType ` also allows add-ins used in multiple contexts to distinguish how the host is currently presenting them.

Compatibility

• Existing add-ins have no visual change when  modalConfig.style  is omitted.
• The two style options are independent and never imply one another.
• The client does not manipulate framework-specific modal backdrops.
• Pre-existing body classes and style elements are preserved.